### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/cnjon/react-native-pdf-view/issues"
-  },
-  "peerDependencies": {
-    "react-native": "^0.21.0"
   }
 }


### PR DESCRIPTION
peerDependencies make it impossible to use RC versions of RN. It's generally agreed that they're bad practice and should be removed.