### PR TITLE
createViewInstance should return a new instance

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.0-beta1'
     }
 }
 
@@ -21,6 +21,9 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 repositories {
@@ -29,5 +32,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.20.+'
-    compile 'com.joanzapata.pdfview:android-pdfview:1.0.4@aar'
+    compile 'com.github.barteksc:android-pdf-viewer:2.0.2'
 }

--- a/android/src/main/java/com/keyee/pdfview/PDFViewManager.java
+++ b/android/src/main/java/com/keyee/pdfview/PDFViewManager.java
@@ -26,7 +26,6 @@ import static java.lang.String.format;
 public class PDFViewManager extends SimpleViewManager<PDFView> implements OnPageChangeListener,OnLoadCompleteListener {
     private static final String REACT_CLASS = "RCTPDFViewAndroid";
     private Context context;
-    private PDFView pdfView;
     Integer pageNumber = 1;
     String assetName;
     String filePath;
@@ -43,11 +42,7 @@ public class PDFViewManager extends SimpleViewManager<PDFView> implements OnPage
 
     @Override
     public PDFView createViewInstance(ThemedReactContext context) {
-        if (pdfView == null){
-            pdfView = new PDFView(context, null);
-        }
-        return pdfView;
-        //return new PDFView(context, null);
+        return new PDFView(context, null);
     }
 
     @Override
@@ -58,17 +53,17 @@ public class PDFViewManager extends SimpleViewManager<PDFView> implements OnPage
 
     @Override
     public void loadComplete(int nbPages) {
-        WritableMap event = Arguments.createMap();
-        event.putString("message", ""+nbPages);
-        ReactContext reactContext = (ReactContext)pdfView.getContext();
-        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-            pdfView.getId(),
-            "topChange",
-            event
-         );
+        // WritableMap event = Arguments.createMap();
+        // event.putString("message", ""+nbPages);
+        // ReactContext reactContext = (ReactContext)pdfView.getContext();
+        // reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+        //     pdfView.getId(),
+        //     "topChange",
+        //     event
+        //  );
     }
 
-    private void display(boolean jumpToFirstPage) {
+    private void display(PDFView pdfView, boolean jumpToFirstPage) {
         if (jumpToFirstPage)
             pageNumber = 1;
         showLog(format("display %s %s", filePath, pageNumber));
@@ -97,7 +92,7 @@ public class PDFViewManager extends SimpleViewManager<PDFView> implements OnPage
     @ReactProp(name = "asset")
     public void setAsset(PDFView view, String ast) {
         assetName = ast;
-        display(false);
+        display(view, false);
     }
 
     @ReactProp(name = "pageNumber")
@@ -105,27 +100,27 @@ public class PDFViewManager extends SimpleViewManager<PDFView> implements OnPage
         //view.setPageNumber(pageNum);
         if (pageNum > 0){
             pageNumber = pageNum;
-            display(false);
+            display(view, false);
         }
     }
 
     @ReactProp(name = "path")
     public void setPath(PDFView view, String pth) {
         filePath = pth;
-        display(false);
+        display(view, false);
     }
 
     @ReactProp(name = "src")
     public void setSrc(PDFView view, String src) {
         //view.setSource(src);
         filePath = src;
-        display(false);
+        display(view, false);
     }
 
     @ReactProp(name = "zoom")
     public void zoomTo(PDFView view, float zoomScale) {
         PointF pivot = new PointF(zoomScale, zoomScale);
-        pdfView.zoomCenteredTo(zoomScale, pivot);
+        view.zoomCenteredTo(zoomScale, pivot);
     }
 
     private void showLog(final String str) {

--- a/android/src/main/java/com/keyee/pdfview/PDFViewManager.java
+++ b/android/src/main/java/com/keyee/pdfview/PDFViewManager.java
@@ -6,9 +6,10 @@ import android.content.Context;
 import android.util.Log;
 import android.graphics.PointF;
 
-import com.joanzapata.pdfview.PDFView;
-import com.joanzapata.pdfview.listener.OnPageChangeListener;
-import com.joanzapata.pdfview.listener.OnLoadCompleteListener;
+import com.github.barteksc.pdfviewer.PDFView;
+import com.github.barteksc.pdfviewer.listener.OnPageChangeListener;
+import com.github.barteksc.pdfviewer.listener.OnLoadCompleteListener;
+
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -70,7 +71,6 @@ public class PDFViewManager extends SimpleViewManager<PDFView> implements OnPage
         if (assetName != null) {
             pdfView.fromAsset(assetName)
                 .defaultPage(pageNumber)
-                .swipeVertical(true)
                 .onPageChange(this)
                 .onLoad(this)
                 .load();
@@ -82,7 +82,6 @@ public class PDFViewManager extends SimpleViewManager<PDFView> implements OnPage
                 .defaultPage(pageNumber)
                 //.showMinimap(false)
                 //.enableSwipe(true)
-                .swipeVertical(true)
                 .onPageChange(this)
                 .onLoad(this)
                 .load();


### PR DESCRIPTION
**DO NOT MERGE**

Returning an existing PDFView instance leads to hard-to-debug but app-crashing issues when displaying more than one PDF at a time.

We aren't using the loadComplete callback so we commented it out for now, but we'll need to figure out how best to access the pdfView variable without storing it locally.