### PR TITLE
fix typescript types in accordance to update within @types/react-native

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import * as ReactNative from 'react-native';
 
 interface Props {
-  style?: React.ViewStyle,
+  style?: ReactNative.ViewStyle,
   path: string,
   src?: string,
   asset?: string,


### PR DESCRIPTION
Because of [this update in @types/react-native](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/a60dca20d86e7100914e345eae8f09f7feedc8bf#diff-b0df5bc3b30d492172d8ecae7ff97bf1) types for this project currently do not work. This PR fixes it.

@sibelius can you, please, merge it?